### PR TITLE
Update auth config to use NEXT_PUBLIC env variables

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -21,7 +21,9 @@ export async function POST(request: Request) {
     const { token } = validatedData.data;
 
     // Set a session cookie for middleware to read
-    cookies().set('session', token, {
+    (await
+      // Set a session cookie for middleware to read
+      cookies()).set('session', token, {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
         maxAge: 60 * 60 * 24 * 7, // One week

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -6,7 +6,9 @@ import { cookies } from 'next/headers';
 export async function POST(request: Request) {
   try {
     // Clear the session cookie
-    cookies().set('session', '', {
+    (await
+      // Clear the session cookie
+      cookies()).set('session', '', {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
         maxAge: -1, // Expire the cookie immediately

--- a/src/components/features/login-view.tsx
+++ b/src/components/features/login-view.tsx
@@ -20,7 +20,8 @@ export default function LoginView() {
         callbackUrl: window.location.origin,
         resetPasswordUrl: window.location.origin,
         OtpLength: 5,
-        OtpType: 'ALPHANUMERICONLYCAPSLETTER'
+        OtpType: 'ALPHANUMERICONLYCAPSLETTER',
+        verificationUrl: process.env.NEXT_PUBLIC_BASE_URL + '/login'
       };
 
       var LRObject = new window.LoginRadiusSDK(commonOptions);

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -65,12 +65,12 @@ export async function registerUser(data: RegisterInput): Promise<any> {
             },
             {
                 params: {
-                    apikey: process.env.LOGINRADIUS_API_KEY,
+                    apikey: process.env.NEXT_PUBLIC_LOGINRADIUS_APIKEY,
                     verificationurl: `${process.env.BASE_URL}/api/auth/verify`
                 },
                 headers: {
                     'Content-Type': 'application/json',
-                    'X-LoginRadius-Sott': process.env.LOGINRADIUS_SOTT // SOTT required for registration
+                    'X-LoginRadius-Sott': process.env.NEXT_PUBLIC_LOGINRADIUS_SOTT // SOTT required for registration
                 }
             }
         );
@@ -91,7 +91,7 @@ export async function loginUser(data: LoginInput): Promise<any> {
             },
             {
                 params: {
-                    apikey: process.env.LOGINRADIUS_API_KEY,
+                    apikey: process.env.NEXT_PUBLIC_LOGINRADIUS_APIKEY,
                     apisecret: process.env.LOGINRADIUS_API_SECRET,
                 },
                 headers: { 'Content-Type': 'application/json' }
@@ -109,7 +109,7 @@ export async function validateAccessToken(token: string): Promise<any> {
              `${process.env.LOGINRADIUSBASE_URL}/identity/v2/auth/access_token/validate`,
              {
                 params: {
-                    apikey: process.env.LOGINRADIUS_API_KEY,
+                    apikey: process.env.NEXT_PUBLIC_LOGINRADIUS_APIKEY,
                     apisecret: process.env.LOGINRADIUS_API_SECRET,
                 },
                 headers: { 
@@ -130,7 +130,7 @@ export async function getUserProfile(accessToken: string): Promise<any> {
             `${process.env.LOGINRADIUSBASE_URL}/identity/v2/auth/account`,
             {
                 params: {
-                    apikey: process.env.LOGINRADIUS_API_KEY
+                    apikey: process.env.NEXT_PUBLIC_LOGINRADIUS_APIKEY
                 },
                 headers: {
                     'Authorization': `Bearer ${accessToken}`,
@@ -151,7 +151,7 @@ export async function updateUserProfile(accessToken: string, profileFields: Reco
             {FirstName: profileFields.name, Company: profileFields.phase},
             {
                 params: {
-                    apikey: process.env.LOGINRADIUS_API_KEY
+                    apikey: process.env.NEXT_PUBLIC_LOGINRADIUS_APIKEY
                 },
                 headers: {
                     'Authorization': `Bearer ${accessToken}`,
@@ -171,7 +171,7 @@ export async function verifyEmail(vtoken: string): Promise<any> {
             `${process.env.LOGINRADIUSBASE_URL}/identity/v2/auth/email`,
             {
                 params: {
-                    apikey: process.env.LOGINRADIUS_API_KEY,
+                    apikey: process.env.NEXT_PUBLIC_LOGINRADIUS_APIKEY,
                     verificationtoken: vtoken,
                     verificationtype: 'emailverification'
                 }


### PR DESCRIPTION
Replaced usage of LOGINRADIUS_API_KEY and LOGINRADIUS_SOTT with NEXT_PUBLIC prefixed environment variables in auth-service. Updated login and logout API routes to await cookies() before setting session cookies. Added verificationUrl to LoginRadiusSDK options in login-view.