### PR TITLE
Add notification registry API and service

### DIFF
--- a/src/app/api/medications/[medicineId]/route.ts
+++ b/src/app/api/medications/[medicineId]/route.ts
@@ -1,7 +1,7 @@
 // src/app/api/medications/[medicineId]/route.ts
 import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
-import { getMedicationById, updateMedication, deleteMedication, isValidMedicationType, VALID_MEDICATION_TYPES } from '@/services/medication-service';
+import { getMedicationById, updateMedication, deleteMedication, isValidMedicationType, VALID_MEDICATION_TYPES, isValidFrequency, VALID_FREQUENCIES } from '@/services/medication-service';
 
 // GET: Retrieve a single medication by ID
 export async function GET(
@@ -68,7 +68,7 @@ export async function PUT(
         }
 
         const body = await request.json();
-        const { title, frequency, dosage, type } = body;
+        const { title, frequency, dosage, type, reminderTime, weekday, notificationId } = body;
 
         // Validate type if provided
         if (type !== undefined && !isValidMedicationType(type)) {
@@ -77,16 +77,53 @@ export async function PUT(
             }, { status: 400 });
         }
 
+        // Validate frequency if provided
+        if (frequency !== undefined && !isValidFrequency(frequency)) {
+            return NextResponse.json({
+                error: `Invalid frequency. Must be one of: ${VALID_FREQUENCIES.join(', ')}`,
+            }, { status: 400 });
+        }
+
         // Validate title if provided (cannot be empty string)
         if (title !== undefined && (typeof title !== 'string' || title.trim() === '')) {
             return NextResponse.json({ error: 'Title cannot be empty.' }, { status: 400 });
         }
 
-        const updateData: Record<string, string> = {};
+        // Validate reminderTime if provided
+        if (reminderTime !== undefined) {
+            const { hour, minute } = reminderTime ?? {};
+            if (
+                typeof hour !== 'number' || !Number.isInteger(hour) || hour < 0 || hour > 23 ||
+                typeof minute !== 'number' || !Number.isInteger(minute) || minute < 0 || minute > 59
+            ) {
+                return NextResponse.json({
+                    error: 'Invalid reminderTime. hour must be 0–23 and minute must be 0–59.',
+                }, { status: 400 });
+            }
+        }
+
+        // Validate weekday if provided
+        if (weekday !== undefined) {
+            if (typeof weekday !== 'number' || !Number.isInteger(weekday) || weekday < 0 || weekday > 6) {
+                return NextResponse.json({
+                    error: 'Invalid weekday. Must be an integer 0 (Sun) – 6 (Sat).',
+                }, { status: 400 });
+            }
+        }
+
+        // Validate notificationId if provided
+        if (notificationId !== undefined && (typeof notificationId !== 'string' || notificationId.trim() === '')) {
+            return NextResponse.json({ error: 'notificationId must be a non-empty string.' }, { status: 400 });
+        }
+
+        const updateData: Record<string, unknown> = {};
         if (title !== undefined) updateData.title = title.trim();
         if (frequency !== undefined) updateData.frequency = frequency;
         if (dosage !== undefined) updateData.dosage = dosage;
         if (type !== undefined) updateData.type = type;
+        if (reminderTime !== undefined) updateData.reminderTime = reminderTime;
+        if (weekday !== undefined) updateData.weekday = weekday;
+        if (notificationId !== undefined) updateData.notificationId = notificationId;
 
         await updateMedication(medicineId, userId, updateData);
 

--- a/src/app/api/medications/route.ts
+++ b/src/app/api/medications/route.ts
@@ -1,7 +1,7 @@
 // src/app/api/medications/route.ts
 import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
-import { addMedication, getMedications, isValidMedicationType, VALID_MEDICATION_TYPES } from '@/services/medication-service';
+import { addMedication, getMedications, isValidMedicationType, VALID_MEDICATION_TYPES, isValidFrequency, VALID_FREQUENCIES } from '@/services/medication-service';
 
 // GET: List all medications for the authenticated user
 export async function GET(request: Request) {
@@ -42,11 +42,18 @@ export async function POST(request: Request) {
         const userId = session.user.id;
         const body = await request.json();
 
-        const { title, frequency, dosage, type } = body;
+        const { title, frequency, dosage, type, reminderTime, weekday, notificationId } = body;
 
         // Validate required fields
         if (!title || typeof title !== 'string' || title.trim() === '') {
             return NextResponse.json({ error: 'Title is required.' }, { status: 400 });
+        }
+
+        // Validate frequency if provided
+        if (frequency !== undefined && !isValidFrequency(frequency)) {
+            return NextResponse.json({
+                error: `Invalid frequency. Must be one of: ${VALID_FREQUENCIES.join(', ')}`,
+            }, { status: 400 });
         }
 
         // Validate type if provided
@@ -56,12 +63,42 @@ export async function POST(request: Request) {
             }, { status: 400 });
         }
 
+        // Validate reminderTime if provided
+        if (reminderTime !== undefined) {
+            const { hour, minute } = reminderTime ?? {};
+            if (
+                typeof hour !== 'number' || !Number.isInteger(hour) || hour < 0 || hour > 23 ||
+                typeof minute !== 'number' || !Number.isInteger(minute) || minute < 0 || minute > 59
+            ) {
+                return NextResponse.json({
+                    error: 'Invalid reminderTime. hour must be 0–23 and minute must be 0–59.',
+                }, { status: 400 });
+            }
+        }
+
+        // Validate weekday if provided
+        if (weekday !== undefined) {
+            if (typeof weekday !== 'number' || !Number.isInteger(weekday) || weekday < 0 || weekday > 6) {
+                return NextResponse.json({
+                    error: 'Invalid weekday. Must be an integer 0 (Sun) – 6 (Sat).',
+                }, { status: 400 });
+            }
+        }
+
+        // Validate notificationId if provided
+        if (notificationId !== undefined && (typeof notificationId !== 'string' || notificationId.trim() === '')) {
+            return NextResponse.json({ error: 'notificationId must be a non-empty string.' }, { status: 400 });
+        }
+
         const medicationData = {
             userId,
             title: title.trim(),
             ...(frequency && { frequency }),
             ...(dosage && { dosage }),
             ...(type && { type }),
+            ...(reminderTime !== undefined && { reminderTime }),
+            ...(weekday !== undefined && { weekday }),
+            ...(notificationId && { notificationId }),
         };
 
         const id = await addMedication(medicationData);

--- a/src/app/api/notification-registry/[registrationId]/route.ts
+++ b/src/app/api/notification-registry/[registrationId]/route.ts
@@ -1,0 +1,99 @@
+// src/app/api/notification-registry/[registrationId]/route.ts
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { updateNotificationRegistration, VALID_STATUSES } from '@/services/notification-registry-service';
+
+// PATCH: Update a notification registration by ID
+export async function PATCH(
+    request: Request,
+    { params }: { params: Promise<{ registrationId: string }> }
+) {
+    try {
+        const session = await auth.api.getSession({
+            headers: request.headers,
+        });
+
+        if (!session) {
+            return new Response('Unauthorized', { status: 401 });
+        }
+
+        const userId = session.user.id;
+        const { registrationId } = await params;
+
+        if (!registrationId) {
+            return NextResponse.json({ error: 'Registration ID is required.' }, { status: 400 });
+        }
+
+        const body = await request.json();
+
+        const { expoNotificationId, title, body: notifBody, data, trigger, scheduledAt, repeats, status, deviceId } = body;
+
+        // Validate each provided field
+        if (expoNotificationId !== undefined && (typeof expoNotificationId !== 'string' || expoNotificationId.trim() === '')) {
+            return NextResponse.json({ error: 'expoNotificationId must be a non-empty string.' }, { status: 400 });
+        }
+
+        if (title !== undefined && (typeof title !== 'string' || title.trim() === '')) {
+            return NextResponse.json({ error: 'title must be a non-empty string.' }, { status: 400 });
+        }
+
+        if (notifBody !== undefined && (typeof notifBody !== 'string' || notifBody.trim() === '')) {
+            return NextResponse.json({ error: 'body must be a non-empty string.' }, { status: 400 });
+        }
+
+        if (trigger !== undefined && (typeof trigger !== 'object' || Array.isArray(trigger) || trigger === null)) {
+            return NextResponse.json({ error: 'trigger must be an object.' }, { status: 400 });
+        }
+
+        if (scheduledAt !== undefined && (typeof scheduledAt !== 'string' || scheduledAt.trim() === '')) {
+            return NextResponse.json({ error: 'scheduledAt must be a non-empty string.' }, { status: 400 });
+        }
+
+        if (deviceId !== undefined && (typeof deviceId !== 'string' || deviceId.trim() === '')) {
+            return NextResponse.json({ error: 'deviceId must be a non-empty string.' }, { status: 400 });
+        }
+
+        if (status !== undefined && !VALID_STATUSES.includes(status)) {
+            return NextResponse.json(
+                { error: `status must be one of: ${VALID_STATUSES.join(', ')}` },
+                { status: 400 }
+            );
+        }
+
+        const updates = {
+            ...(expoNotificationId !== undefined && { expoNotificationId: expoNotificationId.trim() }),
+            ...(title !== undefined && { title: title.trim() }),
+            ...(notifBody !== undefined && { body: notifBody.trim() }),
+            ...(data !== undefined && { data }),
+            ...(trigger !== undefined && { trigger }),
+            ...(scheduledAt !== undefined && { scheduledAt: scheduledAt.trim() }),
+            ...(repeats !== undefined && { repeats: repeats === true }),
+            ...(status !== undefined && { status }),
+            ...(deviceId !== undefined && { deviceId: deviceId.trim() }),
+        };
+
+        if (Object.keys(updates).length === 0) {
+            return NextResponse.json({ error: 'No valid fields provided to update.' }, { status: 400 });
+        }
+
+        await updateNotificationRegistration(registrationId, userId, updates);
+
+        return NextResponse.json({ success: true }, { status: 200 });
+    } catch (error) {
+        console.error('Update Notification Registration Error:', error);
+        const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+
+        if (errorMessage === 'Notification registration not found.') {
+            return NextResponse.json({ error: errorMessage }, { status: 404 });
+        }
+
+        if (errorMessage === 'Unauthorized access to notification registration.') {
+            return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+        }
+
+        return NextResponse.json(
+            { error: 'Failed to update notification registration.', details: errorMessage },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/api/notification-registry/route.ts
+++ b/src/app/api/notification-registry/route.ts
@@ -1,0 +1,116 @@
+// src/app/api/notification-registry/route.ts
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import {
+    addNotificationRegistration,
+    getNotificationRegistrations,
+    VALID_SOURCE_TYPES,
+    VALID_STATUSES,
+} from '@/services/notification-registry-service';
+
+// GET: List all notification registrations for the authenticated user
+export async function GET(request: Request) {
+    try {
+        const session = await auth.api.getSession({
+            headers: request.headers,
+        });
+
+        if (!session) {
+            return new Response('Unauthorized', { status: 401 });
+        }
+
+        const registrations = await getNotificationRegistrations(session.user.id);
+
+        return NextResponse.json(registrations, { status: 200 });
+    } catch (error) {
+        console.error('Get Notification Registrations Error:', error);
+        const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+        return NextResponse.json(
+            { error: 'Failed to retrieve notification registrations.', details: errorMessage },
+            { status: 500 }
+        );
+    }
+}
+
+// POST: Create a new notification registration
+export async function POST(request: Request) {
+    try {
+        const session = await auth.api.getSession({
+            headers: request.headers,
+        });
+
+        if (!session) {
+            return new Response('Unauthorized', { status: 401 });
+        }
+
+        const userId = session.user.id;
+        const body = await request.json();
+
+        const { expoNotificationId, sourceType, sourceId, title, body: notifBody, data, trigger, scheduledAt, repeats, status, deviceId } = body;
+
+        // Validate required fields
+        if (!expoNotificationId || typeof expoNotificationId !== 'string' || expoNotificationId.trim() === '') {
+            return NextResponse.json({ error: 'expoNotificationId is required.' }, { status: 400 });
+        }
+
+        if (!sourceType || !VALID_SOURCE_TYPES.includes(sourceType)) {
+            return NextResponse.json(
+                { error: `sourceType is required and must be one of: ${VALID_SOURCE_TYPES.join(', ')}` },
+                { status: 400 }
+            );
+        }
+
+        if (!sourceId || typeof sourceId !== 'string' || sourceId.trim() === '') {
+            return NextResponse.json({ error: 'sourceId is required.' }, { status: 400 });
+        }
+
+        if (!title || typeof title !== 'string' || title.trim() === '') {
+            return NextResponse.json({ error: 'title is required.' }, { status: 400 });
+        }
+
+        if (!notifBody || typeof notifBody !== 'string' || notifBody.trim() === '') {
+            return NextResponse.json({ error: 'body is required.' }, { status: 400 });
+        }
+
+        if (!trigger || typeof trigger !== 'object' || Array.isArray(trigger)) {
+            return NextResponse.json({ error: 'trigger is required and must be an object.' }, { status: 400 });
+        }
+
+        if (!scheduledAt || typeof scheduledAt !== 'string' || scheduledAt.trim() === '') {
+            return NextResponse.json({ error: 'scheduledAt is required.' }, { status: 400 });
+        }
+
+        // Validate optional status field; default to 'active'
+        const resolvedStatus = status ?? 'active';
+        if (!VALID_STATUSES.includes(resolvedStatus)) {
+            return NextResponse.json(
+                { error: `status must be one of: ${VALID_STATUSES.join(', ')}` },
+                { status: 400 }
+            );
+        }
+
+        const id = await addNotificationRegistration({
+            userId,
+            expoNotificationId: expoNotificationId.trim(),
+            sourceType,
+            sourceId: sourceId.trim(),
+            title: title.trim(),
+            body: notifBody.trim(),
+            ...(data !== undefined && { data }),
+            trigger,
+            scheduledAt: scheduledAt.trim(),
+            repeats: repeats === true,
+            status: resolvedStatus,
+            deviceId: deviceId.trim(),
+        });
+
+        return NextResponse.json({ success: true, id }, { status: 201 });
+    } catch (error) {
+        console.error('Create Notification Registration Error:', error);
+        const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+        return NextResponse.json(
+            { error: 'Failed to create notification registration.', details: errorMessage },
+            { status: 500 }
+        );
+    }
+}

--- a/src/services/medication-service.ts
+++ b/src/services/medication-service.ts
@@ -3,14 +3,23 @@ import { db } from '@/lib/firebase';
 import { collection, addDoc, serverTimestamp, query, getDocs, orderBy, Timestamp, deleteDoc, doc, updateDoc, where, getDoc } from 'firebase/firestore';
 
 export type MedicationType = 'tablet' | 'tonic' | 'powder' | 'drops';
+export type MedicationFrequency = 'daily' | 'weekly';
+
+export interface ReminderTime {
+    hour: number;   // 0–23
+    minute: number; // 0–59
+}
 
 export interface Medication {
     id: string;
     userId: string;
     title: string;
-    frequency?: string;
+    frequency?: MedicationFrequency;
     dosage?: string;
     type?: MedicationType;
+    reminderTime?: ReminderTime;
+    weekday?: number;         // 0 (Sun) – 6 (Sat), applicable when frequency = 'weekly'
+    notificationId?: string;  // opaque ID for push notification scheduling
     createdAt?: string;
     updatedAt?: string;
 }
@@ -21,9 +30,14 @@ export interface MedicationData extends Omit<Medication, 'id' | 'createdAt' | 'u
 }
 
 export const VALID_MEDICATION_TYPES: MedicationType[] = ['tablet', 'tonic', 'powder', 'drops'];
+export const VALID_FREQUENCIES: MedicationFrequency[] = ['daily', 'weekly'];
 
 export function isValidMedicationType(type: string): type is MedicationType {
     return VALID_MEDICATION_TYPES.includes(type as MedicationType);
+}
+
+export function isValidFrequency(frequency: string): frequency is MedicationFrequency {
+    return VALID_FREQUENCIES.includes(frequency as MedicationFrequency);
 }
 
 export async function addMedication(medication: Omit<Medication, 'id' | 'createdAt' | 'updatedAt'>): Promise<string> {
@@ -56,6 +70,9 @@ export async function getMedications(userId: string): Promise<Medication[]> {
                 frequency: data.frequency,
                 dosage: data.dosage,
                 type: data.type,
+                reminderTime: data.reminderTime,
+                weekday: data.weekday,
+                notificationId: data.notificationId,
                 createdAt: (data.createdAt as Timestamp)?.toDate().toISOString(),
                 updatedAt: (data.updatedAt as Timestamp)?.toDate()?.toISOString(),
             };
@@ -88,6 +105,9 @@ export async function getMedicationById(medicationId: string, userId: string): P
             frequency: data.frequency,
             dosage: data.dosage,
             type: data.type,
+            reminderTime: data.reminderTime,
+            weekday: data.weekday,
+            notificationId: data.notificationId,
             createdAt: (data.createdAt as Timestamp)?.toDate().toISOString(),
             updatedAt: (data.updatedAt as Timestamp)?.toDate()?.toISOString(),
         };
@@ -98,9 +118,9 @@ export async function getMedicationById(medicationId: string, userId: string): P
 }
 
 export async function updateMedication(
-    medicationId: string, 
-    userId: string, 
-    data: Partial<Pick<Medication, 'title' | 'frequency' | 'dosage' | 'type'>>
+    medicationId: string,
+    userId: string,
+    data: Partial<Pick<Medication, 'title' | 'frequency' | 'dosage' | 'type' | 'reminderTime' | 'weekday' | 'notificationId'>>
 ): Promise<void> {
     try {
         const docRef = doc(db, 'medications', medicationId);

--- a/src/services/notification-registry-service.ts
+++ b/src/services/notification-registry-service.ts
@@ -1,0 +1,130 @@
+// src/services/notification-registry-service.ts
+import { db } from '@/lib/firebase';
+import {
+    collection,
+    addDoc,
+    serverTimestamp,
+    query,
+    getDocs,
+    where,
+    orderBy,
+    doc,
+    getDoc,
+    updateDoc,
+    Timestamp,
+} from 'firebase/firestore';
+
+export type NotificationSourceType = 'medicine' | 'child_vaccine' | 'appointment';
+export type NotificationStatus = 'active' | 'cancelled' | 'delivered';
+
+export const VALID_SOURCE_TYPES: NotificationSourceType[] = ['medicine', 'child_vaccine', 'appointment'];
+export const VALID_STATUSES: NotificationStatus[] = ['active', 'cancelled', 'delivered'];
+
+export interface NotificationTrigger {
+    hour?: number;
+    minute?: number;
+    repeats?: boolean;
+    [key: string]: unknown;
+}
+
+export interface NotificationRegistration {
+    id: string;
+    userId: string;
+    expoNotificationId: string;
+    sourceType: NotificationSourceType;
+    sourceId: string;
+    title: string;
+    body: string;
+    data?: Record<string, unknown>;
+    trigger: NotificationTrigger;
+    scheduledAt: string;
+    repeats: boolean;
+    status: NotificationStatus;
+    deviceId: string;
+    createdAt?: string;
+    updatedAt?: string;
+}
+
+export interface NotificationRegistrationData extends Omit<NotificationRegistration, 'id' | 'createdAt' | 'updatedAt'> {
+    createdAt?: Timestamp;
+    updatedAt?: Timestamp;
+}
+
+export async function addNotificationRegistration(
+    registration: Omit<NotificationRegistration, 'id' | 'createdAt' | 'updatedAt'>
+): Promise<string> {
+    try {
+        const docRef = await addDoc(collection(db, 'notification_registrations'), {
+            ...registration,
+            createdAt: serverTimestamp(),
+            updatedAt: serverTimestamp(),
+        });
+        return docRef.id;
+    } catch (e) {
+        console.error('Error adding notification registration:', e);
+        throw new Error('Could not save notification registration.');
+    }
+}
+
+export async function getNotificationRegistrations(userId: string): Promise<NotificationRegistration[]> {
+    try {
+        const q = query(
+            collection(db, 'notification_registrations'),
+            where('userId', '==', userId),
+            orderBy('createdAt', 'desc')
+        );
+        const snapshot = await getDocs(q);
+        return snapshot.docs.map(docSnap => {
+            const data = docSnap.data() as NotificationRegistrationData;
+            return {
+                id: docSnap.id,
+                userId: data.userId,
+                expoNotificationId: data.expoNotificationId,
+                sourceType: data.sourceType,
+                sourceId: data.sourceId,
+                title: data.title,
+                body: data.body,
+                data: data.data,
+                trigger: data.trigger,
+                scheduledAt: data.scheduledAt,
+                repeats: data.repeats,
+                status: data.status,
+                deviceId: data.deviceId,
+                createdAt: (data.createdAt as Timestamp)?.toDate().toISOString(),
+                updatedAt: (data.updatedAt as Timestamp)?.toDate()?.toISOString(),
+            };
+        });
+    } catch (e) {
+        console.error('Error getting notification registrations:', e);
+        throw new Error('Could not retrieve notification registrations.');
+    }
+}
+
+export async function updateNotificationRegistration(
+    registrationId: string,
+    userId: string,
+    updates: Partial<Pick<NotificationRegistration, 'expoNotificationId' | 'title' | 'body' | 'data' | 'trigger' | 'scheduledAt' | 'repeats' | 'status' | 'deviceId'>>
+): Promise<void> {
+    try {
+        const docRef = doc(db, 'notification_registrations', registrationId);
+        const docSnap = await getDoc(docRef);
+
+        if (!docSnap.exists()) {
+            throw new Error('Notification registration not found.');
+        }
+
+        const data = docSnap.data() as NotificationRegistrationData;
+        if (data.userId !== userId) {
+            throw new Error('Unauthorized access to notification registration.');
+        }
+
+        await updateDoc(docRef, {
+            ...updates,
+            updatedAt: serverTimestamp(),
+        });
+    } catch (e) {
+        console.error('Error updating notification registration:', e);
+        if (e instanceof Error) throw e;
+        throw new Error('Could not update notification registration.');
+    }
+}


### PR DESCRIPTION
Introduce a Firestore-backed notification registry with endpoints and service helpers. Adds POST/GET handlers at /api/notification-registry to create and list registrations (with validation, auth checks, and resolved default status), and a PATCH handler at /api/notification-registry/[registrationId] to update registrations (with per-field validation and authorization). Implements notification-registry-service with types, VALID_SOURCE_TYPES and VALID_STATUSES, and functions addNotificationRegistration, getNotificationRegistrations, and updateNotificationRegistration that persist and query documents in Firestore using server timestamps and basic error handling.