### PR TITLE
Validate weekday as 1-7 in medication APIs

### DIFF
--- a/src/app/api/medications/[medicineId]/route.ts
+++ b/src/app/api/medications/[medicineId]/route.ts
@@ -104,9 +104,9 @@ export async function PUT(
 
         // Validate weekday if provided
         if (weekday !== undefined) {
-            if (typeof weekday !== 'number' || !Number.isInteger(weekday) || weekday < 0 || weekday > 6) {
+            if (typeof weekday !== 'number' || !Number.isInteger(weekday) || weekday < 1 || weekday > 7) {
                 return NextResponse.json({
-                    error: 'Invalid weekday. Must be an integer 0 (Sun) – 6 (Sat).',
+                    error: 'Invalid weekday. Must be an integer 1 (Sun) - 7 (Sat).',
                 }, { status: 400 });
             }
         }

--- a/src/app/api/medications/route.ts
+++ b/src/app/api/medications/route.ts
@@ -78,9 +78,9 @@ export async function POST(request: Request) {
 
         // Validate weekday if provided
         if (weekday !== undefined) {
-            if (typeof weekday !== 'number' || !Number.isInteger(weekday) || weekday < 0 || weekday > 6) {
+            if (typeof weekday !== 'number' || !Number.isInteger(weekday) || weekday < 1 || weekday > 7) {
                 return NextResponse.json({
-                    error: 'Invalid weekday. Must be an integer 0 (Sun) – 6 (Sat).',
+                    error: 'Invalid weekday. Must be an integer 1 (Sun) - 7 (Sat).',
                 }, { status: 400 });
             }
         }


### PR DESCRIPTION
Update weekday validation in the medications POST and PUT endpoints to accept integers 1-7 (Sun-Sat) instead of 0-6, and adjust the error messages accordingly. Changes made in src/app/api/medications/route.ts and src/app/api/medications/[medicineId]/route.ts.