### PR TITLE
Enhance appointment API and service types

### DIFF
--- a/src/app/api/appointment/[appointmentId]/route.ts
+++ b/src/app/api/appointment/[appointmentId]/route.ts
@@ -1,9 +1,12 @@
 // src/app/api/appointment/[appointmentId]/route.ts
 import { NextResponse } from 'next/server';
-import { updateAppointment } from '@/services/appointment-service';
+import { updateAppointment, addAppointment, type AppointmentType } from '@/services/appointment-service';
+import { uploadFileAndGetURL } from '@/services/journal-service';
 import { auth } from '@/lib/auth';
+import { db } from '@/lib/firebase';
+import { doc, getDoc } from 'firebase/firestore';
 
-// Update an appointment with doctor notes and medications
+// Update an appointment with notes, medications, documents, and other fields
 export async function PUT(request: Request, { params }: { params: { appointmentId: string } }) {
     try {
         const session = await auth.api.getSession({
@@ -21,26 +24,166 @@ export async function PUT(request: Request, { params }: { params: { appointmentI
             return new NextResponse(JSON.stringify({ error: 'Appointment ID is required.' }), { status: 400 });
         }
         
-        const data = await request.json();
-        const { doctorNotes, medications } = data;
-
-        const updateData: { doctorNotes?: string; medications?: string } = {};
+        const formData = await request.formData();
         
-        if (doctorNotes !== undefined) {
-            updateData.doctorNotes = doctorNotes;
+        // Extract text fields
+        const notes = formData.get('notes') as string | null;
+        const medicationsJson = formData.get('medications') as string | null;
+        const exercisesJson = formData.get('exercises') as string | null;
+        const followUp = formData.get('followUp') as string | null;
+        const painScoreStr = formData.get('painScore') as string | null;
+        const dietPlan = formData.get('dietPlan') as string | null;
+        const isCancelledStr = formData.get('isCancelled') as string | null;
+        const isRescheduledStr = formData.get('isRescheduled') as string | null;
+
+        const updateData: {
+            notes?: string;
+            medications?: string[];
+            exercises?: string[];
+            followUp?: string;
+            painScore?: number;
+            dietPlan?: string;
+            documents?: string[];
+            isCancelled?: boolean;
+            isRescheduled?: boolean;
+        } = {};
+        
+        // Handle notes
+        if (notes !== null) {
+            updateData.notes = notes;
         }
         
-        if (medications !== undefined) {
-            updateData.medications = medications;
+        // Handle medications array
+        if (medicationsJson !== null) {
+            try {
+                const medications = JSON.parse(medicationsJson);
+                if (Array.isArray(medications)) {
+                    updateData.medications = medications;
+                } else {
+                    return new NextResponse(JSON.stringify({ error: 'medications must be an array.' }), { status: 400 });
+                }
+            } catch {
+                return new NextResponse(JSON.stringify({ error: 'Invalid medications JSON format.' }), { status: 400 });
+            }
+        }
+        
+        // Handle exercises array
+        if (exercisesJson !== null) {
+            try {
+                const exercises = JSON.parse(exercisesJson);
+                if (Array.isArray(exercises)) {
+                    updateData.exercises = exercises;
+                } else {
+                    return new NextResponse(JSON.stringify({ error: 'exercises must be an array.' }), { status: 400 });
+                }
+            } catch {
+                return new NextResponse(JSON.stringify({ error: 'Invalid exercises JSON format.' }), { status: 400 });
+            }
+        }
+        
+        // Handle followUp date
+        if (followUp !== null) {
+            updateData.followUp = followUp;
+        }
+        
+        // Handle pain score with validation
+        if (painScoreStr !== null) {
+            const painScore = parseInt(painScoreStr, 10);
+            if (isNaN(painScore) || painScore < 0 || painScore > 10) {
+                return new NextResponse(JSON.stringify({ error: 'painScore must be an integer between 0 and 10.' }), { status: 400 });
+            }
+            updateData.painScore = painScore;
+        }
+        
+        // Handle diet plan
+        if (dietPlan !== null) {
+            updateData.dietPlan = dietPlan;
+        }
+        
+        // Handle boolean flags
+        if (isCancelledStr !== null) {
+            updateData.isCancelled = isCancelledStr === 'true';
+        }
+        
+        if (isRescheduledStr !== null) {
+            updateData.isRescheduled = isRescheduledStr === 'true';
+        }
+        
+        // Handle document file uploads
+        const documentFiles: File[] = [];
+        let fileIndex = 0;
+        while (true) {
+            const file = formData.get(`document${fileIndex}`) as File | null;
+            if (!file || file.size === 0) break;
+            documentFiles.push(file);
+            fileIndex++;
+        }
+        
+        // Upload documents to Firebase Storage
+        if (documentFiles.length > 0) {
+            const documentUrls: string[] = [];
+            for (const file of documentFiles) {
+                const url = await uploadFileAndGetURL(file, userId, 'appointment-documents');
+                documentUrls.push(url);
+            }
+            updateData.documents = documentUrls;
         }
 
         if (Object.keys(updateData).length === 0) {
-            return new NextResponse(JSON.stringify({ error: 'At least one field (doctorNotes or medications) is required.' }), { status: 400 });
+            return new NextResponse(JSON.stringify({ error: 'At least one field is required to update.' }), { status: 400 });
         }
 
+        // Update the appointment
         await updateAppointment(appointmentId, userId, updateData);
 
-        return new NextResponse(JSON.stringify({ success: true }), { status: 200 });
+        const responseData: { success: boolean; followUpAppointmentId?: string } = { success: true };
+
+        // Create follow-up appointment if followUp date is provided
+        if (followUp) {
+            try {
+                // Fetch the original appointment to get doctor, type, and fastingRequired
+                const appointmentRef = doc(db, 'appointments', appointmentId);
+                const appointmentSnap = await getDoc(appointmentRef);
+                
+                if (appointmentSnap.exists()) {
+                    const appointmentData = appointmentSnap.data();
+                    
+                    const followUpData: {
+                        userId: string;
+                        date: string;
+                        isFollowUp: boolean;
+                        parentAppointmentId: string;
+                        doctor?: string;
+                        type?: AppointmentType;
+                        fastingRequired?: boolean;
+                    } = {
+                        userId,
+                        date: followUp,
+                        isFollowUp: true,
+                        parentAppointmentId: appointmentId,
+                    };
+                    
+                    // Copy doctor, type, and fastingRequired from original appointment
+                    if (appointmentData.doctor) {
+                        followUpData.doctor = appointmentData.doctor;
+                    }
+                    if (appointmentData.type) {
+                        followUpData.type = appointmentData.type as AppointmentType;
+                    }
+                    if (appointmentData.fastingRequired !== undefined) {
+                        followUpData.fastingRequired = appointmentData.fastingRequired;
+                    }
+                    
+                    const followUpAppointmentId = await addAppointment(followUpData);
+                    responseData.followUpAppointmentId = followUpAppointmentId;
+                }
+            } catch (followUpError) {
+                console.error('Error creating follow-up appointment:', followUpError);
+                // Continue even if follow-up creation fails
+            }
+        }
+
+        return new NextResponse(JSON.stringify(responseData), { status: 200 });
 
     } catch (error) {
         console.error('Update Appointment Error:', error);

--- a/src/app/api/appointment/route.ts
+++ b/src/app/api/appointment/route.ts
@@ -1,6 +1,6 @@
 // src/app/api/appointment/route.ts
 import { NextResponse } from 'next/server';
-import { getAppointments, addAppointment } from '@/services/appointment-service';
+import { getAppointments, addAppointment, type AppointmentType } from '@/services/appointment-service';
 import { auth } from "@/lib/auth";
 
 // Get all appointments
@@ -36,20 +36,35 @@ export async function POST(request: Request) {
 
         const userId = session.user.id;
         const body = await request.json();
-        const { date, doctor } = body;
+        const { date, doctor, type, fastingRequired } = body;
 
         if (!date) {
             return new NextResponse(JSON.stringify({ error: 'Date is required.' }), { status: 400 });
         }
 
+        const validTypes = ['doctor', 'lab', 'physiotherapy', 'dietitian', 'mental_wellness'];
+        if (type && !validTypes.includes(type)) {
+            return new NextResponse(JSON.stringify({ error: `Invalid type. Must be one of: ${validTypes.join(', ')}.` }), { status: 400 });
+        }
+
         const dataToSave: {
             userId: string;
             date: string;
+            type?: AppointmentType;
+            fastingRequired?: boolean;
             doctor?: string;
         } = {
             userId,
             date,
         };
+
+        if (type) {
+            dataToSave.type = type as AppointmentType;
+        }
+
+        if (fastingRequired !== undefined) {
+            dataToSave.fastingRequired = Boolean(fastingRequired);
+        }
 
         if (doctor) {
             dataToSave.doctor = doctor;

--- a/src/services/appointment-service.ts
+++ b/src/services/appointment-service.ts
@@ -2,13 +2,26 @@
 import { db } from '@/lib/firebase';
 import { collection, addDoc, serverTimestamp, query, getDocs, orderBy, Timestamp, doc, updateDoc, where, getDoc } from 'firebase/firestore';
 
+export type AppointmentType = 'doctor' | 'lab' | 'physiotherapy' | 'dietitian' | 'mental_wellness';
+
 export interface Appointment {
     id: string;
     userId: string;
     date: string; // ISO date string
+    type?: AppointmentType;
+    fastingRequired?: boolean;
     doctor?: string;
-    doctorNotes?: string;
-    medications?: string;
+    notes?: string;
+    medications?: string[];
+    followUp?: string; // ISO date string for follow-up appointment
+    documents?: string[]; // Array of document URLs
+    exercises?: string[];
+    painScore?: number; // 0-10
+    dietPlan?: string;
+    isFollowUp?: boolean;
+    parentAppointmentId?: string; // Reference to parent appointment if this is a follow-up
+    isCancelled?: boolean;
+    isRescheduled?: boolean;
     createdAt: any; // Can be Timestamp on read, FieldValue on write
     updatedAt?: any;
 }
@@ -17,7 +30,7 @@ export interface AppointmentData extends Omit<Appointment, 'id' | 'createdAt'> {
     createdAt: Timestamp;
 }
 
-export async function addAppointment(appointment: Omit<Appointment, 'id' | 'createdAt' | 'updatedAt' | 'doctorNotes' | 'medications'>) {
+export async function addAppointment(appointment: Omit<Appointment, 'id' | 'createdAt' | 'updatedAt' | 'notes' | 'medications' | 'followUp' | 'documents' | 'exercises' | 'painScore' | 'dietPlan'>) {
     try {
         const docRef = await addDoc(collection(db, 'appointments'), {
             ...appointment,
@@ -30,7 +43,7 @@ export async function addAppointment(appointment: Omit<Appointment, 'id' | 'crea
     }
 }
 
-export async function updateAppointment(appointmentId: string, userId: string, data: Partial<Pick<Appointment, 'doctorNotes' | 'medications'>>): Promise<void> {
+export async function updateAppointment(appointmentId: string, userId: string, data: Partial<Pick<Appointment, 'notes' | 'medications' | 'followUp' | 'documents' | 'exercises' | 'painScore' | 'dietPlan' | 'isCancelled' | 'isRescheduled'>>): Promise<void> {
     try {
         const docRef = doc(db, 'appointments', appointmentId);
         const docSnap = await getDoc(docRef);


### PR DESCRIPTION
Expand appointment endpoints and service types to support richer appointment data and follow-ups. PUT /appointment/[id] now accepts multipart formData (notes, medications/exercises JSON arrays, painScore with validation, dietPlan, boolean flags, document file uploads via uploadFileAndGetURL) and will create a follow-up appointment when followUp is provided (copies doctor/type/fastingRequired from the original). POST /appointment now validates and accepts a type and fastingRequired flag. The Appointment interface and appointment-service signatures were updated (new AppointmentType, notes, arrays for medications/exercises, documents, followUp, painScore, dietPlan, isCancelled/isRescheduled, etc.), and addAppointment/updateAppointment signatures adjusted accordingly.