### PR TITLE
Support tests array in appointment API

### DIFF
--- a/src/app/api/appointment/[appointmentId]/route.ts
+++ b/src/app/api/appointment/[appointmentId]/route.ts
@@ -37,6 +37,7 @@ export async function PUT(request: Request, { params }: { params: { appointmentI
         const isRescheduledStr = formData.get('isRescheduled') as string | null;
         const fastingRequiredStr = formData.get('fastingRequired') as string | null;
         const date = formData.get('date') as string | null;
+        const testsJson = formData.get('tests') as string | null;
 
         const updateData: {
             notes?: string;
@@ -50,6 +51,7 @@ export async function PUT(request: Request, { params }: { params: { appointmentI
             isRescheduled?: boolean;
             fastingRequired?: boolean;
             date?: string;
+            tests?: string[];
         } = {};
         
         // Handle notes
@@ -82,6 +84,20 @@ export async function PUT(request: Request, { params }: { params: { appointmentI
                 }
             } catch {
                 return new NextResponse(JSON.stringify({ error: 'Invalid exercises JSON format.' }), { status: 400 });
+            }
+        }
+        
+        // Handle tests array
+        if (testsJson !== null) {
+            try {
+                const tests = JSON.parse(testsJson);
+                if (Array.isArray(tests) && tests.every(test => typeof test === 'string')) {
+                    updateData.tests = tests;
+                } else {
+                    return new NextResponse(JSON.stringify({ error: 'tests must be an array of strings.' }), { status: 400 });
+                }
+            } catch {
+                return new NextResponse(JSON.stringify({ error: 'Invalid tests JSON format.' }), { status: 400 });
             }
         }
         

--- a/src/app/api/appointment/route.ts
+++ b/src/app/api/appointment/route.ts
@@ -36,7 +36,7 @@ export async function POST(request: Request) {
 
         const userId = session.user.id;
         const body = await request.json();
-        const { date, doctor, type, fastingRequired } = body;
+        const { date, doctor, type, fastingRequired, tests } = body;
 
         if (!date) {
             return new NextResponse(JSON.stringify({ error: 'Date is required.' }), { status: 400 });
@@ -47,12 +47,18 @@ export async function POST(request: Request) {
             return new NextResponse(JSON.stringify({ error: `Invalid type. Must be one of: ${validTypes.join(', ')}.` }), { status: 400 });
         }
 
+        // Validate tests array if provided
+        if (tests !== undefined && (!Array.isArray(tests) || !tests.every(test => typeof test === 'string'))) {
+            return new NextResponse(JSON.stringify({ error: 'tests must be an array of strings.' }), { status: 400 });
+        }
+
         const dataToSave: {
             userId: string;
             date: string;
             type?: AppointmentType;
             fastingRequired?: boolean;
             doctor?: string;
+            tests?: string[];
         } = {
             userId,
             date,
@@ -68,6 +74,10 @@ export async function POST(request: Request) {
 
         if (doctor) {
             dataToSave.doctor = doctor;
+        }
+
+        if (tests && tests.length > 0) {
+            dataToSave.tests = tests;
         }
 
         const newAppointmentId = await addAppointment(dataToSave);


### PR DESCRIPTION
Accept and persist a tests array for appointments. POST handler now reads tests from the request body, validates it's an array of strings, and includes it in data saved and the response. PUT handler parses a JSON-encoded tests field from formData, validates it as an array of strings, applies it to updateData, and returns 400 on invalid format. Added types for tests?: string[] in both handlers.