### PR TITLE
Add pregnancy API routes and service

### DIFF
--- a/src/app/api/pregnancy/[pregnancyId]/route.ts
+++ b/src/app/api/pregnancy/[pregnancyId]/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { getPregnancy, updatePregnancy, type PregnancyStatus } from '@/services/pregnancy-service';
+
+interface RouteParams {
+    params: Promise<{ pregnancyId: string }>;
+}
+
+export async function GET(request: Request, { params }: RouteParams) {
+    try {
+        const session = await auth.api.getSession({ headers: request.headers });
+
+        if (!session) {
+            return new Response('Unauthorized', { status: 401 });
+        }
+
+        const { pregnancyId } = await params;
+        const pregnancy = await getPregnancy(pregnancyId);
+
+        if (!pregnancy) {
+            return NextResponse.json({ error: 'Pregnancy record not found.' }, { status: 404 });
+        }
+
+        if (pregnancy.userId !== session.user.id) {
+            return NextResponse.json({ error: 'Forbidden.' }, { status: 403 });
+        }
+
+        return NextResponse.json({ pregnancy });
+    } catch (error) {
+        console.error('Get Pregnancy Error:', error);
+        const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+        return NextResponse.json(
+            { error: 'Failed to fetch pregnancy record.', details: errorMessage },
+            { status: 500 }
+        );
+    }
+}
+
+export async function PATCH(request: Request, { params }: RouteParams) {
+    try {
+        const session = await auth.api.getSession({ headers: request.headers });
+
+        if (!session) {
+            return new Response('Unauthorized', { status: 401 });
+        }
+
+        const { pregnancyId } = await params;
+        const pregnancy = await getPregnancy(pregnancyId);
+
+        if (!pregnancy) {
+            return NextResponse.json({ error: 'Pregnancy record not found.' }, { status: 404 });
+        }
+
+        if (pregnancy.userId !== session.user.id) {
+            return NextResponse.json({ error: 'Forbidden.' }, { status: 403 });
+        }
+
+        const data = await request.json();
+        const { babyNickname, dueDate, status } = data;
+
+        // Validate status if provided
+        const validStatuses: PregnancyStatus[] = ['active', 'completed', 'miscarried'];
+        if (status !== undefined && !validStatuses.includes(status)) {
+            return NextResponse.json(
+                { error: `Invalid status. Must be one of: ${validStatuses.join(', ')}.` },
+                { status: 400 }
+            );
+        }
+
+        // Validate dueDate if provided
+        let parsedDueDate: Date | undefined;
+        if (dueDate !== undefined) {
+            parsedDueDate = new Date(dueDate);
+            if (isNaN(parsedDueDate.getTime())) {
+                return NextResponse.json(
+                    { error: 'Invalid dueDate format. Must be a valid ISO date string.' },
+                    { status: 400 }
+                );
+            }
+        }
+
+        const updated = await updatePregnancy(pregnancyId, {
+            babyNickname,
+            dueDate: parsedDueDate,
+            status,
+        });
+
+        // Handle side-effects of status transitions
+        if (status === 'completed') {
+            // Flip user phase to post_delivery, keep pregnancyId for history
+            await auth.api.updateUser({
+                body: { phase: 'post_delivery' },
+                headers: request.headers,
+            });
+        } else if (status === 'miscarried') {
+            // Clear pregnancyId from user record
+            // await auth.api.updateUser({
+            //     body: { pregnancyId: '' },
+            //     headers: request.headers,
+            // });
+        }
+
+        return NextResponse.json({ success: true, pregnancy: updated });
+    } catch (error) {
+        console.error('Update Pregnancy Error:', error);
+        const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+        return NextResponse.json(
+            { error: 'Failed to update pregnancy record.', details: errorMessage },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/api/pregnancy/route.ts
+++ b/src/app/api/pregnancy/route.ts
@@ -1,0 +1,102 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import {
+    createPregnancy,
+    // getActivePregnancyByUserId,
+    getPregnancy,
+    type CalculationMethod,
+    type PregnancyType,
+} from '@/services/pregnancy-service';
+
+export async function POST(request: Request) {
+    try {
+        const session = await auth.api.getSession({ headers: request.headers });
+
+        if (!session) {
+            return new Response('Unauthorized', { status: 401 });
+        }
+
+        const userId = session.user.id;
+
+        const data = await request.json();
+        const {
+            dueDate,
+            lmpDate,
+            cycleLengthDays,
+            babyNickname,
+            pregnancyType,
+        } = data;
+
+        if (!dueDate && !lmpDate) {
+            return NextResponse.json(
+                { error: 'Either dueDate or lmpDate is required.' },
+                { status: 400 }
+            );
+        }
+
+        let parsedDueDate: Date;
+        let calculationMethod: CalculationMethod;
+
+        if (dueDate) {
+            parsedDueDate = new Date(dueDate);
+            if (isNaN(parsedDueDate.getTime())) {
+                return NextResponse.json(
+                    { error: 'Invalid dueDate format. Must be a valid ISO date string.' },
+                    { status: 400 }
+                );
+            }
+            calculationMethod = 'dueDate';
+        } else {
+            // Calculate due date from LMP: 280 days + cycle length adjustment (default cycle = 28 days)
+            const parsedLmpDate = new Date(lmpDate);
+            if (isNaN(parsedLmpDate.getTime())) {
+                return NextResponse.json(
+                    { error: 'Invalid lmpDate format. Must be a valid ISO date string.' },
+                    { status: 400 }
+                );
+            }
+            const cycleAdjustment = cycleLengthDays ? Number(cycleLengthDays) - 28 : 0;
+            parsedDueDate = new Date(parsedLmpDate);
+            parsedDueDate.setDate(parsedDueDate.getDate() + 280 + cycleAdjustment);
+            calculationMethod = 'lmp';
+        }
+
+        const validTypes: PregnancyType[] = ['singleton', 'twins', 'triplets', 'other'];
+        if (pregnancyType && !validTypes.includes(pregnancyType)) {
+            return NextResponse.json(
+                { error: `Invalid pregnancyType. Must be one of: ${validTypes.join(', ')}.` },
+                { status: 400 }
+            );
+        }
+
+        const pregnancyId = await createPregnancy({
+            userId,
+            dueDate: parsedDueDate,
+            calculationMethod,
+            lmpDate: lmpDate ? new Date(lmpDate) : undefined,
+            cycleLengthDays: cycleLengthDays ? Number(cycleLengthDays) : undefined,
+            babyNickname: babyNickname ?? undefined,
+            pregnancyType: pregnancyType as PregnancyType | undefined,
+        });
+
+        // Store pregnancyId on the user record
+        await auth.api.updateUser({
+            body: { pregnancyId },
+            headers: request.headers,
+        });
+
+        const pregnancy = await getPregnancy(pregnancyId);
+
+        return NextResponse.json(
+            { success: true, pregnancyId, pregnancy },
+            { status: 201 }
+        );
+    } catch (error) {
+        console.error('Create Pregnancy Error:', error);
+        const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+        return NextResponse.json(
+            { error: 'Failed to create pregnancy record.', details: errorMessage },
+            { status: 500 }
+        );
+    }
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -48,6 +48,10 @@ export const auth = betterAuth({
       childrenIds: {
         type: "string[]",
         required: false,
+      },
+      pregnancyId: {
+        type: "string",
+        required: false,
       }
     }
   },

--- a/src/services/pregnancy-service.ts
+++ b/src/services/pregnancy-service.ts
@@ -1,0 +1,158 @@
+import { db } from '@/lib/firebase';
+import {
+    doc,
+    getDoc,
+    addDoc,
+    updateDoc,
+    collection,
+    query,
+    where,
+    getDocs,
+    serverTimestamp,
+    Timestamp,
+} from 'firebase/firestore';
+
+export type PregnancyStatus = 'active' | 'completed' | 'miscarried';
+export type CalculationMethod = 'lmp' | 'dueDate';
+export type PregnancyType = 'singleton' | 'twins' | 'triplets' | 'other';
+
+export interface PregnancyRecord {
+    id: string;
+    userId: string;
+    calculationMethod: CalculationMethod;
+    dueDate: string;
+    lmpDate?: string;
+    cycleLengthDays?: number;
+    babyNickname?: string;
+    pregnancyType: PregnancyType;
+    status: PregnancyStatus;
+    createdAt: string;
+    updatedAt: string;
+}
+
+interface CreatePregnancyInput {
+    userId: string;
+    dueDate: Date;
+    calculationMethod?: CalculationMethod;
+    lmpDate?: Date;
+    cycleLengthDays?: number;
+    babyNickname?: string;
+    pregnancyType?: PregnancyType;
+}
+
+interface UpdatePregnancyInput {
+    babyNickname?: string;
+    dueDate?: Date;
+    status?: PregnancyStatus;
+}
+
+export async function createPregnancy(input: CreatePregnancyInput): Promise<string> {
+    try {
+        const docRef = await addDoc(collection(db, 'pregnancies'), {
+            userId: input.userId,
+            calculationMethod: input.calculationMethod ?? 'lmp',
+            dueDate: Timestamp.fromDate(input.dueDate),
+            lmpDate: input.lmpDate ? Timestamp.fromDate(input.lmpDate) : null,
+            cycleLengthDays: input.cycleLengthDays ?? null,
+            babyNickname: input.babyNickname ?? null,
+            pregnancyType: input.pregnancyType ?? 'singleton',
+            status: 'active' as PregnancyStatus,
+            createdAt: serverTimestamp(),
+            updatedAt: serverTimestamp(),
+        });
+
+        return docRef.id;
+    } catch (e) {
+        console.error('Error creating pregnancy:', e);
+        throw new Error('Could not create pregnancy record.');
+    }
+}
+
+export async function getPregnancy(pregnancyId: string): Promise<PregnancyRecord | null> {
+    if (!pregnancyId) return null;
+
+    try {
+        const docRef = doc(db, 'pregnancies', pregnancyId);
+        const docSnap = await getDoc(docRef);
+
+        if (!docSnap.exists()) {
+            return null;
+        }
+
+        const data = docSnap.data();
+
+        return {
+            id: docSnap.id,
+            userId: data.userId,
+            calculationMethod: data.calculationMethod,
+            dueDate: (data.dueDate as Timestamp)?.toDate().toISOString(),
+            lmpDate: data.lmpDate ? (data.lmpDate as Timestamp).toDate().toISOString() : undefined,
+            cycleLengthDays: data.cycleLengthDays ?? undefined,
+            babyNickname: data.babyNickname ?? undefined,
+            pregnancyType: data.pregnancyType,
+            status: data.status,
+            createdAt: (data.createdAt as Timestamp)?.toDate().toISOString(),
+            updatedAt: (data.updatedAt as Timestamp)?.toDate().toISOString(),
+        };
+    } catch (e) {
+        console.error('Error fetching pregnancy:', e);
+        throw new Error('Could not fetch pregnancy record.');
+    }
+}
+
+export async function getActivePregnancyByUserId(userId: string): Promise<PregnancyRecord | null> {
+    try {
+        const q = query(
+            collection(db, 'pregnancies'),
+            where('userId', '==', userId),
+            where('status', '==', 'active')
+        );
+
+        const snapshot = await getDocs(q);
+
+        if (snapshot.empty) return null;
+
+        const docSnap = snapshot.docs[0];
+        const data = docSnap.data();
+
+        return {
+            id: docSnap.id,
+            userId: data.userId,
+            calculationMethod: data.calculationMethod,
+            dueDate: (data.dueDate as Timestamp)?.toDate().toISOString(),
+            lmpDate: data.lmpDate ? (data.lmpDate as Timestamp).toDate().toISOString() : undefined,
+            cycleLengthDays: data.cycleLengthDays ?? undefined,
+            babyNickname: data.babyNickname ?? undefined,
+            pregnancyType: data.pregnancyType,
+            status: data.status,
+            createdAt: (data.createdAt as Timestamp)?.toDate().toISOString(),
+            updatedAt: (data.updatedAt as Timestamp)?.toDate().toISOString(),
+        };
+    } catch (e) {
+        console.error('Error querying active pregnancy:', e);
+        throw new Error('Could not query active pregnancy.');
+    }
+}
+
+export async function updatePregnancy(pregnancyId: string, input: UpdatePregnancyInput): Promise<PregnancyRecord> {
+    const docRef = doc(db, 'pregnancies', pregnancyId);
+
+    const updates: Record<string, unknown> = {
+        updatedAt: serverTimestamp(),
+    };
+
+    if (input.babyNickname !== undefined) updates.babyNickname = input.babyNickname;
+    if (input.dueDate !== undefined) updates.dueDate = Timestamp.fromDate(input.dueDate);
+    if (input.status !== undefined) updates.status = input.status;
+
+    try {
+        await updateDoc(docRef, updates);
+
+        const updated = await getPregnancy(pregnancyId);
+        if (!updated) throw new Error('Pregnancy record not found after update.');
+        return updated;
+    } catch (e) {
+        console.error('Error updating pregnancy:', e);
+        throw new Error('Could not update pregnancy record.');
+    }
+}


### PR DESCRIPTION
Introduce pregnancy management: add POST /api/pregnancy and GET/PATCH /api/pregnancy/[pregnancyId] endpoints, and a pregnancy-service backed by Firestore. The service provides createPregnancy, getPregnancy, getActivePregnancyByUserId and updatePregnancy with types for status, calculation method and pregnancy type, handles Timestamp conversions and serverTimestamp for created/updated fields. Routes perform auth checks, input validation (dueDate/LMP parsing, status/type whitelists), calculate due date from LMP when needed, store pregnancyId on the user when creating, and handle status side-effects (update user phase to post_delivery on completion). Also extend auth schema to include an optional pregnancyId field.