### PR TITLE
Add iOS fitness API and Firestore service

### DIFF
--- a/src/app/api/fitness/ios/route.ts
+++ b/src/app/api/fitness/ios/route.ts
@@ -1,0 +1,118 @@
+// src/app/api/fitness/ios/route.ts
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import {
+    getFitnessHistory,
+    getStepGoal,
+    isValidFitnessDataPoint,
+    MAX_STEP_GOAL,
+    MIN_STEP_GOAL,
+    setStepGoal,
+    upsertFitnessData,
+} from '@/services/fitness-service';
+
+const DEFAULT_DAYS = 7;
+const MAX_DAYS = 31;
+
+// GET /api/fitness/ios?days=7 — fetch fitness history and step goal for the authenticated user (iOS/HealthKit only)
+export async function GET(request: Request) {
+    try {
+        const session = await auth.api.getSession({
+            headers: request.headers,
+        });
+
+        if (!session) {
+            return new Response("Unauthorized", { status: 401 });
+        }
+
+        const userId = session.user.id;
+
+        const { searchParams } = new URL(request.url);
+        const daysParam = Number(searchParams.get('days'));
+        const days = Number.isInteger(daysParam) && daysParam > 0
+            ? Math.min(daysParam, MAX_DAYS)
+            : DEFAULT_DAYS;
+
+        const [data, stepGoal] = await Promise.all([
+            getFitnessHistory(userId, days),
+            getStepGoal(userId),
+        ]);
+
+        return NextResponse.json({ data, stepGoal }, { status: 200 });
+    } catch (error) {
+        console.error('Get Fitness History Error:', error);
+        const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+        return NextResponse.json({ error: 'Failed to fetch fitness history.', details: errorMessage }, { status: 500 });
+    }
+}
+
+// POST /api/fitness/ios — sync HealthKit fitness data points for the authenticated user (iOS only)
+export async function POST(request: Request) {
+    try {
+        const session = await auth.api.getSession({
+            headers: request.headers,
+        });
+
+        if (!session) {
+            return new Response("Unauthorized", { status: 401 });
+        }
+
+        const userId = session.user.id;
+        const body = await request.json();
+        const { data } = body;
+
+        if (!Array.isArray(data) || data.length === 0) {
+            return NextResponse.json({ error: 'data must be a non-empty array of fitness data points.' }, { status: 400 });
+        }
+
+        if (!data.every(isValidFitnessDataPoint)) {
+            return NextResponse.json({
+                error: 'Each fitness data point must have a date (YYYY-MM-DD) and non-negative steps, stairsClimbed, and caloriesBurned.',
+            }, { status: 400 });
+        }
+
+        await upsertFitnessData(userId, data);
+
+        return NextResponse.json({ success: true }, { status: 201 });
+    } catch (error) {
+        console.error('Sync Fitness Data Error:', error);
+        const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+        return NextResponse.json({ error: 'Failed to sync fitness data.', details: errorMessage }, { status: 500 });
+    }
+}
+
+// PUT /api/fitness/ios — update the authenticated user's daily step goal
+export async function PUT(request: Request) {
+    try {
+        const session = await auth.api.getSession({
+            headers: request.headers,
+        });
+
+        if (!session) {
+            return new Response("Unauthorized", { status: 401 });
+        }
+
+        const userId = session.user.id;
+        const body = await request.json();
+        const { stepGoal } = body;
+
+        if (
+            typeof stepGoal !== 'number' ||
+            !Number.isInteger(stepGoal) ||
+            stepGoal < MIN_STEP_GOAL ||
+            stepGoal > MAX_STEP_GOAL
+        ) {
+            return NextResponse.json({
+                error: `stepGoal must be an integer between ${MIN_STEP_GOAL} and ${MAX_STEP_GOAL}.`,
+            }, { status: 400 });
+        }
+
+        await setStepGoal(userId, stepGoal);
+
+        return NextResponse.json({ success: true, stepGoal }, { status: 200 });
+    } catch (error) {
+        console.error('Update Step Goal Error:', error);
+        const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+        return NextResponse.json({ error: 'Failed to update step goal.', details: errorMessage }, { status: 500 });
+    }
+}

--- a/src/services/fitness-service.ts
+++ b/src/services/fitness-service.ts
@@ -1,0 +1,83 @@
+// src/services/fitness-service.ts
+import { db } from '@/lib/firebase';
+import { collection, doc, getDoc, getDocs, limit, orderBy, query, setDoc, where } from 'firebase/firestore';
+
+export const DEFAULT_STEP_GOAL = 7000;
+export const MIN_STEP_GOAL = 1000;
+export const MAX_STEP_GOAL = 100000;
+
+export interface FitnessDataPoint {
+    date: string; // 'YYYY-MM-DD'
+    steps: number;
+    stairsClimbed: number;
+    caloriesBurned: number;
+}
+
+interface FitnessDataDoc extends FitnessDataPoint {
+    userId: string;
+}
+
+const DATE_KEY_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+export function isValidFitnessDataPoint(point: any): point is FitnessDataPoint {
+    return (
+        point &&
+        typeof point.date === 'string' &&
+        DATE_KEY_REGEX.test(point.date) &&
+        typeof point.steps === 'number' && point.steps >= 0 &&
+        typeof point.stairsClimbed === 'number' && point.stairsClimbed >= 0 &&
+        typeof point.caloriesBurned === 'number' && point.caloriesBurned >= 0
+    );
+}
+
+export async function upsertFitnessData(userId: string, points: FitnessDataPoint[]): Promise<void> {
+    await Promise.all(points.map(point => {
+        const docId = `${userId}_${point.date}`;
+        const docRef = doc(db, 'fitnessData', docId);
+        const data: FitnessDataDoc = {
+            userId,
+            date: point.date,
+            steps: point.steps,
+            stairsClimbed: point.stairsClimbed,
+            caloriesBurned: point.caloriesBurned,
+        };
+        return setDoc(docRef, data, { merge: true });
+    }));
+}
+
+export async function getFitnessHistory(userId: string, days: number): Promise<FitnessDataPoint[]> {
+    const fitnessCol = collection(db, 'fitnessData');
+    const q = query(
+        fitnessCol,
+        where('userId', '==', userId),
+        orderBy('date', 'desc'),
+        limit(days),
+    );
+    const snapshot = await getDocs(q);
+
+    const points: FitnessDataPoint[] = [];
+    snapshot.forEach(docSnap => {
+        const data = docSnap.data() as FitnessDataDoc;
+        points.push({
+            date: data.date,
+            steps: data.steps,
+            stairsClimbed: data.stairsClimbed,
+            caloriesBurned: data.caloriesBurned,
+        });
+    });
+
+    // Return oldest → newest to match the mobile client's expected ordering.
+    return points.sort((a, b) => a.date.localeCompare(b.date));
+}
+
+export async function getStepGoal(userId: string): Promise<number> {
+    const docRef = doc(db, 'userProfiles', userId);
+    const docSnap = await getDoc(docRef);
+    const stepGoal = docSnap.exists() ? docSnap.data().stepGoal : undefined;
+    return typeof stepGoal === 'number' && stepGoal > 0 ? stepGoal : DEFAULT_STEP_GOAL;
+}
+
+export async function setStepGoal(userId: string, stepGoal: number): Promise<void> {
+    const docRef = doc(db, 'userProfiles', userId);
+    await setDoc(docRef, { stepGoal }, { merge: true });
+}


### PR DESCRIPTION
Introduces a new `/api/fitness/ios` route with authenticated GET, POST, and PUT handlers for fetching fitness history + step goal, syncing HealthKit-style daily metrics, and updating step goals. Adds a dedicated `fitness-service` for Firestore reads/writes, data-point validation, step-goal bounds/defaults, and consistent oldest-to-newest history ordering for the mobile client.